### PR TITLE
Fix feed loading quirks on Windows

### DIFF
--- a/gtfs_kit/feed.py
+++ b/gtfs_kit/feed.py
@@ -486,11 +486,13 @@ def _read_feed_from_url(url: str, dist_units: str) -> "Feed":
 
 
     """
-    r = requests.get(url)
-    with tempfile.NamedTemporaryFile() as f:
+    f = tempfile.NamedTemporaryFile(delete=False)
+    with requests.get(url) as r:
         f.write(r._content)
-        f.seek(0)
-        return _read_feed_from_path(f.name, dist_units=dist_units)
+    f.close()
+    feed = _read_feed_from_path(f.name, dist_units=dist_units)
+    Path(f.name).unlink()
+    return feed
 
 
 def read_feed(path_or_url: Union[Path, str], dist_units: str) -> "Feed":

--- a/gtfs_kit/feed.py
+++ b/gtfs_kit/feed.py
@@ -509,7 +509,11 @@ def read_feed(path_or_url: Union[Path, str], dist_units: str) -> "Feed":
     - Automatically strip whitespace from the column names in GTFS files
 
     """
-    if Path(path_or_url).exists():
+    try:
+        path_exists = Path(path_or_url).exists()
+    except OSError:
+        path_exists = False
+    if path_exists:
         return _read_feed_from_path(path_or_url, dist_units=dist_units)
     elif requests.head(path_or_url).ok:
         return _read_feed_from_url(path_or_url, dist_units=dist_units)


### PR DESCRIPTION
- _read_feed_from_url() is broken; unlike on *nix, you [cannot](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) open a file handle twice on Windows.
- read_feed() distinguishes between file paths and URL's by calling Path.exists(), but Windows jumps the gun and raises WinError 123 (incorrect path syntax) when said path is a URL.