### PR TITLE
fix: Update format of crs for geopandas

### DIFF
--- a/gtfs_kit/constants.py
+++ b/gtfs_kit/constants.py
@@ -139,7 +139,7 @@ FEED_ATTRS_2 = ["_trips_i", "_calendar_i", "_calendar_dates_g"]
 FEED_ATTRS = FEED_ATTRS_1 + FEED_ATTRS_2
 
 #: WGS84 coordinate reference system for Geopandas
-WGS84 = {"init": "epsg:4326"}
+WGS84 = "epsg:4326"
 
 #: Colorbrewer 8-class Set2 colors
 COLORS_SET2 = [


### PR DESCRIPTION
I ran into this warning:

```
*** FutureWarning: '+init=<authority>:<code>' syntax is deprecated. 
'<authority>:<code>' is the preferred initialization method. When making 
the change, be mindful of axis order changes:
https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6
```

when calling `feed.append_dist_to_stop_times()`, with a stack trace of

```
Traceback (most recent call last):
  File "/Users/gdurazo/.asdf/installs/python/3.6.8/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/gdurazo/.asdf/installs/python/3.6.8/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/gdurazo/mbta/gtfs_creator/gtfs_creator2/gtfs/recap.py", line 36, in <module>
    feed = main(feed, hastus_calendar)
  File "/Users/gdurazo/mbta/gtfs_creator/gtfs_creator2/gtfs/recap.py", line 22, in main
    feed.stop_times = feed.copy().append_dist_to_stop_times().stop_times
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/gtfs_kit/stop_times.py", line 52, in append_dist_to_stop_times
    geom_by_stop = feed.build_geometry_by_stop(use_utm=True)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/gtfs_kit/stops.py", line 641, in build_geometry_by_stop
    geometrize_stops(feed, stop_ids=stop_ids, use_utm=True)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/gtfs_kit/stops.py", line 631, in geometrize_stops
    return geometrize_stops_0(stops, use_utm=use_utm)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/gtfs_kit/stops.py", line 590, in geometrize_stops_0
    .pipe(lambda x: gpd.GeoDataFrame(x, crs=cs.WGS84))
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pandas/core/generic.py", line 5028, in pipe
    return com._pipe(self, func, *args, **kwargs)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pandas/core/common.py", line 483, in _pipe
    return func(obj, *args, **kwargs)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/gtfs_kit/stops.py", line 590, in <lambda>
    .pipe(lambda x: gpd.GeoDataFrame(x, crs=cs.WGS84))
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/geopandas/geodataframe.py", line 65, in __init__
    self.crs = crs
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/geopandas/geodataframe.py", line 97, in __setattr__
    super(GeoDataFrame, self).__setattr__(attr, val)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pandas/core/generic.py", line 5192, in __setattr__
    return object.__setattr__(self, name, value)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/geopandas/base.py", line 153, in crs
    self._crs = None if not value else CRS.from_user_input(value)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pyproj/crs/crs.py", line 440, in from_user_input
    return CRS(value, **kwargs)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pyproj/crs/crs.py", line 282, in __init__
    projstring = _prepare_from_dict(projparams)
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pyproj/crs/crs.py", line 53, in _prepare_from_dict
    return _prepare_from_string(" ".join(pjargs))
  File "/Users/gdurazo/.local/share/virtualenvs/gtfs_creator-CYIxk2eg/lib/python3.6/site-packages/pyproj/crs/crs.py", line 102, in _prepare_from_string
    stacklevel=2,
FutureWarning: '+init=<authority>:<code>' syntax is deprecated. '<authority>:<code>' is the preferred initialization method. When making the change, be mindful of axis order changes: https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6
```

I believe the issue is that calling `gpd.GeoDataFrame(x, crs=cs.WGS84)`, where `cs.WGS84` is `{"init": "epsg:4326"}`, is deprecated.

When I made the change in this PR locally, as far as I can tell, it worked fined without a warning. But I'm not that experienced with this code, or python in general, so I may be missing something...