### PR TITLE
suggestions for faster busiest date calculation

### DIFF
--- a/gtfs_kit/feed.py
+++ b/gtfs_kit/feed.py
@@ -16,6 +16,7 @@ parameter in the method signatures.
 Ignore that extra parameter; it refers to the Feed instance,
 usually called ``self`` and usually hidden automatically by Sphinx.
 """
+
 from pathlib import Path
 import tempfile
 import shutil
@@ -277,6 +278,9 @@ class Feed(object):
             self._calendar_dates_g = self._calendar_dates.groupby(
                 ["service_id", "date"]
             )
+            self._calendar_dates_i = val.set_index(["service_id", "date"])[
+                "exception_type"
+            ]
         else:
             self._calendar_dates_g = None
 

--- a/notebooks/busiest.py
+++ b/notebooks/busiest.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+from pathlib import Path
+
+import gtfs_kit as gk
+from gtfs_kit.miscellany import restrict_to_dates
+
+logFormat = "%(asctime)s %(name)s %(levelname)s | %(message)s"
+logging.basicConfig(format=logFormat, datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+
+
+def reduce_gtfs(in_file: Path, out_file: Path):
+    logger.info(f"loading {in_file}")
+    feed = gk.read_feed(in_file, dist_units="km")
+    feed.describe()
+
+    logger.info("computing busiest date")
+    busiest_date = feed.compute_busiest_date(feed.get_dates())
+    logger.info(f"reducing feed to trips on {busiest_date}")
+    restricted_feed = restrict_to_dates(feed, [busiest_date])
+    logger.info(f"writing reduced feed to {out_file}")
+    restricted_feed.write(out_file)
+
+
+if __name__ == "__main__":
+    # run times in debugger:
+    # original: ~5 minutes
+    # .. using indexed calendar_dates instead of groups: ~4 minutes
+    # .. and with weekdays precalculated: <2:40 minutes
+    if len(sys.argv) != 3:
+        raise ValueError("call with exactly two arguments: input and output gtfs.zip")
+
+    reduce_gtfs(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
I noticed that the method for calculating the busiest date for a takes quite a long time and had a look at it. For a real-world sized feed of mine the proposed changes reduced the time from 5 minutes to 2:40.

Tests still pass and comparing the extracted feeds from my test script also showed an empty diff.