### PR TITLE
Fix clean_times deprecation warning

### DIFF
--- a/gtfs_kit/cleaners.py
+++ b/gtfs_kit/cleaners.py
@@ -102,7 +102,7 @@ def clean_times(feed: "Feed") -> "Feed":
     for table, columns in tables_and_columns:
         f = getattr(feed, table)
         if f is not None:
-            f[columns] = f[columns].applymap(reformat)
+            f[columns] = f[columns].apply(lambda x: x.map(reformat))
         setattr(feed, table, f)
 
     return feed

--- a/gtfs_kit/miscellany.py
+++ b/gtfs_kit/miscellany.py
@@ -1,6 +1,7 @@
 """
 Functions about miscellany.
 """
+
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
@@ -259,8 +260,8 @@ def compute_feed_stats_0(
     stop_times = feed.stop_times.copy()
 
     # Convert timestrings to seconds for quicker calculations
-    ts[["start_time", "end_time"]] = ts[["start_time", "end_time"]].applymap(
-        hp.timestr_to_seconds
+    ts[["start_time", "end_time"]] = ts[["start_time", "end_time"]].apply(
+        lambda x: x.map(hp.timestr_to_seconds)
     )
 
     if split_route_types:
@@ -319,8 +320,8 @@ def compute_feed_stats_0(
 
     # Convert seconds back to timestrings
     times = ["peak_start_time", "peak_end_time"]
-    stats[times] = stats[times].applymap(
-        lambda t: hp.timestr_to_seconds(t, inverse=True)
+    stats[times] = stats[times].apply(
+        lambda x: x.map(lambda t: hp.timestr_to_seconds(t, inverse=True))
     )
 
     return stats
@@ -907,9 +908,8 @@ def compute_screen_line_counts(
     # Get intersection points of shapes and screen lines
     g0 = (
         # Only keep shapes that intersect screen lines to reduce computations
-        gp.sjoin(shapes_g, screen_lines.filter(["screen_line_id", "geometry"])).merge(
-            screen_lines, on="screen_line_id"
-        )
+        gp.sjoin(shapes_g, screen_lines.filter(["screen_line_id", "geometry"]))
+        .merge(screen_lines, on="screen_line_id")
         # Compute intersection points
         .assign(
             int_point=lambda x: gp.GeoSeries(x["geometry_x"], crs=crs).intersection(
@@ -973,7 +973,8 @@ def compute_screen_line_counts(
     st = (
         feed.trips.loc[lambda x: x["shape_id"].isin(h.index)]
         # Merge in route short names and stop times
-        .merge(feed.routes[["route_id", "route_short_name"]]).merge(feed.stop_times)
+        .merge(feed.routes[["route_id", "route_short_name"]])
+        .merge(feed.stop_times)
         # Keep only non-NaN departure times
         .loc[lambda x: x["departure_time"].notna()]
         # Convert to seconds past midnight

--- a/gtfs_kit/stops.py
+++ b/gtfs_kit/stops.py
@@ -1,6 +1,7 @@
 """
 Functions about stops.
 """
+
 from __future__ import annotations
 from collections import Counter
 from typing import Optional, Iterable, TYPE_CHECKING
@@ -127,8 +128,8 @@ def compute_stop_stats_0(
     result = g.apply(compute_stop_stats).reset_index()
 
     # Convert start and end times to time strings
-    result[["start_time", "end_time"]] = result[["start_time", "end_time"]].applymap(
-        lambda x: hp.timestr_to_seconds(x, inverse=True)
+    result[["start_time", "end_time"]] = result[["start_time", "end_time"]].apply(
+        lambda x: x.map(lambda t: hp.timestr_to_seconds(t, inverse=True))
     )
 
     return result
@@ -304,7 +305,7 @@ def compute_stop_activity(feed: "Feed", dates: list[str]) -> pd.DataFrame:
     # Pandas won't allow me to simply return g[dates].max().reset_index().
     # I get ``TypeError: unorderable types: datetime.date() < str()``.
     # So here's a workaround.
-    for (i, date) in enumerate(dates):
+    for i, date in enumerate(dates):
         if i == 0:
             f = g[date].max().reset_index()
         else:

--- a/gtfs_kit/trips.py
+++ b/gtfs_kit/trips.py
@@ -1,6 +1,7 @@
 """
 Functions about trips.
 """
+
 from __future__ import annotations
 import json
 from typing import Optional, Iterable, TYPE_CHECKING
@@ -326,8 +327,8 @@ def compute_trip_stats(
     # Reset index and compute final stats
     h = h.reset_index()
     h["speed"] = h["distance"] / h["duration"]
-    h[["start_time", "end_time"]] = h[["start_time", "end_time"]].applymap(
-        lambda x: hp.timestr_to_seconds(x, inverse=True)
+    h[["start_time", "end_time"]] = h[["start_time", "end_time"]].apply(
+        lambda x: x.map(lambda t: hp.timestr_to_seconds(t, inverse=True))
     )
 
     return h.sort_values(["route_id", "direction_id", "start_time"])
@@ -546,7 +547,7 @@ def map_trips(
                     # trip direction equals LineString direction
                     fp.PolyLineTextPath(
                         path,
-                        "        \u27A4        ",
+                        "        \u27a4        ",
                         repeat=True,
                         offset=5.5,
                         attributes={"fill": color, "font-size": "18"},


### PR DESCRIPTION
Pandas `Dataframe.applymap` is deprecated since version 2.1.0 which raises a deprecation warning in `cleaners.clean_times`. Here is a quick fix for the issue😄. All tests seem to pass.