### PR TITLE
Added gdf compatibility to `build_geometry_by_shape`

### DIFF
--- a/gtfs_kit/shapes.py
+++ b/gtfs_kit/shapes.py
@@ -148,21 +148,29 @@ def get_shapes(
 
 
 def build_geometry_by_shape(
-    feed: "Feed", shape_ids: Iterable[str] | None = None, *, use_utm: bool = False
+    feed: "Feed",
+    shape_ids: Iterable[str] | None = None,
+    *,
+    as_gdf: bool = False,
+    use_utm: bool = False
 ) -> dict:
     """
-    Return a dictionary of the form
+    Get specific shapes from a feed in ``shape_ids``.
+    If ``as_gdf``, then return it as GeoDataFrame with a 'geometry' column, otherwise
+    return a dictionary containing:
     <shape ID> -> <Shapely LineString representing shape>.
-    If the Feed has no shapes, then return the empty dictionary.
+    If the Feed has no shapes, then return the empty item.
     If ``use_utm``, then use local UTM coordinates; otherwise, use WGS84 coordinates.
     """
     if feed.shapes is None:
-        return dict()
+        return gpd.GeoDataFrame() if as_gdf else dict()
 
     g = get_shapes(feed, as_gdf=True, use_utm=use_utm)
     if shape_ids is not None:
         g = g.loc[lambda x: x["shape_id"].isin(shape_ids)]
-    return dict(g[["shape_id", "geometry"]].values)
+    
+    g = g[["shape_id", "geometry"]]
+    return g if as_gdf else dict(g.values)
 
 
 def shapes_to_geojson(feed: "Feed", shape_ids: Iterable[str] | None = None) -> dict:

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -75,9 +75,12 @@ def test_get_shapes():
 
 def test_build_geometry_by_shape():
     d = gks.build_geometry_by_shape(cairns)
+    g = gks.build_geometry_by_shape(cairns, as_gdf=True)
     assert isinstance(d, dict)
+    assert isinstance(g, gpd.GeoDataFrame)
     assert len(d) == cairns.shapes.shape_id.nunique()
     assert gks.build_geometry_by_shape(cairns_shapeless) == {}
+    assert gks.build_geometry_by_shape(cairns_shapeless, as_gdf=True).empty
 
 
 def test_shapes_to_geojson():


### PR DESCRIPTION
Hello,

First of all - this is a great project! I'm starting to work with GTFS feeds regularly at my work, so I'm looking for a platform on which to do it easily. I started using your repository and it has been a huge help in understanding GTFS and working with them in an uncomplicated way.

I'd like to do this more regularly, perhaps with more substantive changes, and possibly help out, but I would need a hand as I am quite new to git management. As I haven't done any major repository editing / implementation before, I thought I'd submit a little PR here. Let me know if this fits with what you're looking for.

___

I've added compatibility and tests for returning a GeoDataFrame in the build_geometry_by_shape function. This allows users to filter the shapes as a GeoDataFrame with a 'geometry' column when the as_gdf parameter is set to True. If as_gdf is False (default), the function will return the shapes as a dictionary.