### PR TITLE
Fixing depreciation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # mkdocs documentation
 /site
+
+# vim .swp files
+.swp

--- a/gtfs_kit/helpers.py
+++ b/gtfs_kit/helpers.py
@@ -8,6 +8,7 @@ from typing import Callable
 import copy
 from bisect import bisect_left, bisect_right
 from functools import cmp_to_key
+from pathlib import Path
 import math
 
 import pandas as pd
@@ -16,6 +17,13 @@ import shapely.geometry as sg
 import json2html as j2h
 
 from . import constants as cs
+
+
+def get_project_root() -> Path:
+    """
+    Returns the root directory of the project as Path.
+    """
+    return Path(__file__).absolute().parent.parent
 
 
 def datestr_to_date(

--- a/gtfs_kit/routes.py
+++ b/gtfs_kit/routes.py
@@ -208,7 +208,7 @@ def compute_route_stats_0(
             )
 
         g = (
-            f.groupby(["route_id", "direction_id"])
+            f.groupby(["route_id", "direction_id"])[f.columns]
             .apply(compute_route_stats_split_directions)
             .reset_index()
         )
@@ -219,10 +219,12 @@ def compute_route_stats_0(
             d["is_bidirectional"] = int(group["direction_id"].unique().size > 1)
             return pd.Series(d)
 
-        gg = g.groupby("route_id").apply(is_bidirectional).reset_index()
+        gg = g.groupby("route_id")[g.columns].apply(is_bidirectional).\
+            reset_index()
         g = g.merge(gg)
     else:
-        g = f.groupby("route_id").apply(compute_route_stats).reset_index()
+        g = f.groupby("route_id")[f.columns].apply(compute_route_stats).\
+            reset_index()
 
     # Compute a few more stats
     g["service_speed"] = (g["service_distance"] / g["service_duration"]).fillna(
@@ -728,7 +730,7 @@ def get_routes(
             .drop_duplicates(subset="shape_id")
             .filter(groupby_cols + ["geometry"])
             .groupby(groupby_cols)
-            .apply(merge_lines)
+            .apply(merge_lines, include_groups=False)
             .reset_index()
             .merge(f, how="right")
             .pipe(gpd.GeoDataFrame)

--- a/gtfs_kit/shapes.py
+++ b/gtfs_kit/shapes.py
@@ -87,8 +87,7 @@ def geometrize_shapes(
 
     g = (
         shapes.sort_values(["shape_id", "shape_pt_sequence"])
-        .groupby("shape_id", sort=False)
-        .apply(my_agg)
+        .groupby("shape_id", sort=False)[shapes.columns].apply(my_agg)
         .reset_index()
         .pipe(gpd.GeoDataFrame)
         .set_crs(cs.WGS84)

--- a/gtfs_kit/stop_times.py
+++ b/gtfs_kit/stop_times.py
@@ -111,7 +111,10 @@ def append_dist_to_stop_times(feed: "Feed") -> "Feed":
         # Convert departure times to seconds to ease calculatios
         .assign(departure_time_s=lambda x: x.departure_time.map(hp.timestr_to_seconds))
         .sort_values(["trip_id", "stop_sequence"])
-        .groupby("trip_id", group_keys=False)
+    )
+
+    st = (
+        st.groupby("trip_id", group_keys=False)[st.columns]
         .apply(compute_dist)
         .reset_index()
         # Convert distances from meters to feed's distance units

--- a/gtfs_kit/stops.py
+++ b/gtfs_kit/stops.py
@@ -156,7 +156,7 @@ def compute_stop_stats_0(
     else:
         g = f.groupby("stop_id")
 
-    result = g.apply(compute_stop_stats).reset_index()
+    result = g[f.columns].apply(compute_stop_stats).reset_index()
 
     # Convert start and end times to time strings
     result[["start_time", "end_time"]] = result[["start_time", "end_time"]].map(

--- a/gtfs_kit/trips.py
+++ b/gtfs_kit/trips.py
@@ -110,7 +110,7 @@ def get_trips(
                 d["is_active"] = result
                 return pd.Series(d)
 
-            h = g.groupby("trip_id").apply(F).reset_index()
+            h = g.groupby("trip_id").apply(F, include_groups=False).reset_index()
             f = pd.merge(f, h[h["is_active"]])
             del f["is_active"]
 
@@ -194,7 +194,10 @@ def name_stop_patterns(feed: "Feed") -> pd.DataFrame:
     f = (
         feed.stop_times.sort_values(["trip_id", "stop_sequence"])
         .groupby("trip_id")
-        .apply(lambda x: pd.Series({"stop_pattern": "-".join(x["stop_id"])}))
+        .apply(
+            lambda x: pd.Series({"stop_pattern": "-".join(x["stop_id"])}),
+            include_groups=False
+        )
         .reset_index()
         .merge(trips[["route_id", "trip_id", "direction_id"]])
     )
@@ -323,7 +326,7 @@ def compute_trip_stats(
     # Apply my_agg, but don't reset index yet.
     # Need trip ID as index to line up the results of the
     # forthcoming distance calculation
-    h = g.apply(my_agg)
+    h = g.apply(my_agg, include_groups=False)
 
     # Compute distance
     if hp.is_not_null(f, "shape_dist_traveled") and not compute_dist_from_shapes:
@@ -333,7 +336,8 @@ def compute_trip_stats(
         else:
             convert_dist = hp.get_convert_dist(feed.dist_units, "mi")
         h["distance"] = g.apply(
-            lambda group: convert_dist(group.shape_dist_traveled.max())
+            lambda group: convert_dist(group.shape_dist_traveled.max()),
+            include_groups=False
         )
     elif feed.shapes is not None:
         # Compute distances using the shapes and Shapely
@@ -389,7 +393,7 @@ def compute_trip_stats(
                 # return the length of the linestring
                 return D
 
-        h["distance"] = g.apply(compute_dist)
+        h["distance"] = g.apply(compute_dist, include_groups=False)
         # Convert from meters
         h["distance"] = h["distance"].map(m_to_dist)
     else:
@@ -450,13 +454,17 @@ def locate_trips(feed: "Feed", date: str, times: list[str]) -> pd.DataFrame:
     def compute_rel_dist(group):
         dists = sorted(group["shape_dist_traveled"].values)
         times = sorted(group["departure_time"].values)
-        ts = sample_times[(sample_times >= times[0]) & (sample_times <= times[-1])]
+        ts = sample_times[
+            (sample_times >= times[0]) &
+            (sample_times <= times[-1])
+        ]
         ds = np.interp(ts, times, dists)
         return pd.DataFrame({"time": ts, "rel_dist": ds / dists[-1]})
 
     # return f.groupby('trip_id', group_keys=False).\
     #   apply(compute_rel_dist).reset_index()
-    g = f.groupby("trip_id").apply(compute_rel_dist).reset_index()
+    g = f.groupby("trip_id").apply(compute_rel_dist, include_groups=False).\
+        reset_index()
 
     # Delete extraneous multi-index column
     del g["level_1"]
@@ -488,7 +496,15 @@ def locate_trips(feed: "Feed", date: str, times: list[str]) -> pd.DataFrame:
         group["lon"], group["lat"] = zip(*lonlats)
         return group
 
-    return h.groupby("shape_id").apply(get_lonlat)
+    columns = [
+        'shape_id',
+        'trip_id',
+        'route_id',
+        'direction_id',
+        'time',
+        'rel_dist'
+    ]
+    return h.groupby("shape_id")[columns].apply(get_lonlat)
 
 
 def trips_to_geojson(

--- a/tests/context.py
+++ b/tests/context.py
@@ -24,3 +24,5 @@ cairns_dates = [week[0], week[2]]
 cairns_trip_stats = pd.read_csv(
     DATA_DIR / "cairns_trip_stats.csv", dtype=gtfs_kit.DTYPE
 )
+
+pd.set_option('future.no_silent_downcasting', True)

--- a/tests/context.py
+++ b/tests/context.py
@@ -11,7 +11,7 @@ import gtfs_kit
 
 
 # Load/create test feeds
-DATA_DIR = Path("data")
+DATA_DIR = Path(gtfs_kit.helpers.get_project_root() / "data")
 sample = gtfs_kit.read_feed(DATA_DIR / "sample_gtfs.zip", dist_units="km")
 cairns = gtfs_kit.read_feed(DATA_DIR / "cairns_gtfs.zip", dist_units="km")
 cairns_shapeless = cairns.copy()

--- a/tests/test_miscellany.py
+++ b/tests/test_miscellany.py
@@ -323,6 +323,7 @@ def test_restrict_to_area():
 
 
 @pytest.mark.slow
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
 def test_compute_screen_line_counts():
     feed = cairns.append_dist_to_stop_times()
     dates = cairns_dates + ["20010101"]

--- a/tests/test_stop_times.py
+++ b/tests/test_stop_times.py
@@ -39,6 +39,7 @@ def test_get_start_and_end_times():
 
 
 @pytest.mark.slow
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
 def test_append_dist_to_stop_times():
     feed1 = cairns.copy()
     st1 = feed1.stop_times

--- a/tests/test_trips.py
+++ b/tests/test_trips.py
@@ -167,6 +167,7 @@ def test_compute_trip_stats():
 
 
 @pytest.mark.slow
+@pytest.mark.filterwarnings('ignore::RuntimeWarning')
 def test_locate_trips():
     feed = cairns.copy()
     feed = gks.append_dist_to_stop_times(feed)


### PR DESCRIPTION
👋 This PR makes a lot of minor changes to fix warnings. Should see no warnings when tests are run, even when running from a different repository.

[See this commit](https://github.com/mrcagney/gtfs_kit/commit/49c7f378ef3a9cc36c19a028cca8ca086d5725df)

```txt
Correcting instances of .apply use where depreciation warnings are flagged.

Filtering RuntimeWarnings - maybe consider isolating the bad stops and not passing the calculation on to shapely to avoid warning and increased runtime.

Also set pandas option for no_silent_downcasting to avoid [depreciation] warning.

Added vim .swp files to gitignore for ease [of use].
```