### PR TITLE
Fix sorting by departure time in timetables

### DIFF
--- a/gtfs_kit/routes.py
+++ b/gtfs_kit/routes.py
@@ -665,6 +665,7 @@ def build_route_timetable(
         frames.append(f)
 
     f = pd.concat(frames)
+    f["min_dt"] = f["min_dt"].map(hp.timestr_to_seconds)
     return f.sort_values(["date", "min_dt", "stop_sequence"]).drop(
         ["min_dt", "dt"], axis=1
     )

--- a/gtfs_kit/stops.py
+++ b/gtfs_kit/stops.py
@@ -610,7 +610,10 @@ def build_stop_timetable(feed: "Feed", stop_id: str, dates: list[str]) -> pd.Dat
         frames.append(f)
 
     f = pd.concat(frames)
-    return f.sort_values(["date", "departure_time"])
+    f["departure_time"] = f["departure_time"].map(hp.timestr_to_seconds)
+    f = f.sort_values(["date", "departure_time"])
+    f["departure_time"] = f["departure_time"].apply(hp.timestr_to_seconds, inverse=True)
+    return f
 
 
 def build_geometry_by_stop(


### PR DESCRIPTION
I was playing with this package - very useful by the way - and generating some timetables when I noticed that they were not sorting correctly. Even though `stops.build_stop_timetable()` and `routes.build_route_timetable()` sort the output by departure time, because that is a string, pandas sorts it lexicographically - placing e.g. 10:00:00 before 9:59:59. Fortunately there's already a helper function to convert time strings to seconds after midnight, so we can use that before sorting. The fix seemed straightforward so here's some commits for it.