### PR TITLE
More comprehensive null check

### DIFF
--- a/gtfs_kit/feed.py
+++ b/gtfs_kit/feed.py
@@ -384,7 +384,12 @@ def _read_feed_from_path(path: pl.Path, dist_units: str) -> "Feed":
         ):
             # utf-8-sig gets rid of the byte order mark (BOM);
             # see http://stackoverflow.com/questions/17912307/u-ufeff-in-python-string
-            df = pd.read_csv(p, dtype=cs.DTYPE, encoding="utf-8-sig")
+            csv_options = {
+                'na_values': ['', ' ', 'nan', 'NaN', 'null'],  # Add space to na_values
+                'keep_default_na': True,
+                'dtype_backend': 'numpy_nullable'  # Use nullable dtypes
+            }
+            df = pd.read_csv(p, dtype=cs.DTYPE, encoding="utf-8-sig", **csv_options)
             if not df.empty:
                 feed_dict[table] = cn.clean_column_names(df)
 


### PR DESCRIPTION
# Improved CSV parsing for better handling of empty/whitespace values

## Problem
The current implementation of `read_feed` fails when encountering empty spaces or missing values in GTFS files, particularly with numeric fields. This causes the error `ValueError: Unable to parse string " " at position 0` when processing real-world GTFS feeds that contain imperfect data. I encountered this problem while using the [SFMTA latest feed](https://data.sfgov.org/Transportation/SFMTA-General-Transit-Feed-Specification-GTFS-Prod/dni7-qpv3/about_data)

## Solution
This PR modifies the CSV reading options to better handle empty values, whitespace, and missing data by:
1. Adding explicit handling for empty/whitespace values
2. Using nullable dtypes for numeric columns
3. Ensuring consistent string handling for ID fields

### Changes
```python
# Modified _read_feed_from_path function
csv_options = {
    'na_values': ['', ' ', 'nan', 'NaN', 'null'],  # Add space to na_values
    'keep_default_na': True,
    'dtype_backend': 'numpy_nullable'  # Use nullable dtypes
}
df = pd.read_csv(p, dtype=cs.DTYPE, encoding="utf-8-sig", **csv_options)
```

## Example
Before this change:
```python
# Fails with ValueError when encountering spaces/empty values
stop_id,stop_lat,stop_lon
1001,42.3601, 
1002, ,71.0589
```

After this change:
```python
# Successfully loads with proper NaN handling
   stop_id  stop_lat  stop_lon
0    1001   42.3601       NaN
1    1002       NaN   71.0589
```

## Testing
- Tested with sample GTFS feeds containing various forms of missing/empty data
- I ran the tests using pytest. For some reason, 6 tests were failing. However, those tests were failing irrespective of the changes.